### PR TITLE
Updated functions to match new methods in CF7 plugin

### DIFF
--- a/modules/mailpoet-signup.php
+++ b/modules/mailpoet-signup.php
@@ -131,65 +131,99 @@ function wpcf7_mailpoetsignup_validation_filter( $result, $tag ) {
 add_action( 'admin_init', 'wpcf7_add_tag_generator_mailpoetsignup', 20 );
 
 function wpcf7_add_tag_generator_mailpoetsignup() {
-	if ( ! function_exists( 'wpcf7_add_tag_generator' ) ) {
-		return;
-	}
+	// if ( ! function_exists( 'wpcf7_add_tag_generator' ) ) {
+	// 	return;
+	// }
 
-	wpcf7_add_tag_generator( 'mailpoetsignup', __( 'Mailpoet Signup', 'mpcf7' ),
-		'wpcf7-tg-pane-mailpoetsignup', 'wpcf7_tg_pane_mailpoetsignup' );
+	// wpcf7_add_tag_generator( 'mailpoetsignup', __( 'Mailpoet Signup', 'mpcf7' ),
+	// 	'wpcf7-tg-pane-mailpoetsignup', 'wpcf7_tg_pane_mailpoetsignup' );
+
+	$tag_generator = WPCF7_TagGenerator::get_instance();
+	$tag_generator->add( 'mailpoetsignup', __( 'Mailpoet Signup', 'mpcf7' ),
+		'wpcf7_tg_pane_mailpoetsignup' );
 }
 
-function wpcf7_tg_pane_mailpoetsignup( $contact_form ) {
+
+function wpcf7_tg_pane_mailpoetsignup( $contact_form, $args = '' ) {
+
+	$args = wp_parse_args( $args, array() );
+	$type = 'mailpoetsignup';
+
+	$description = __( "Mailpoet Signup Form.", 'mpcf7' );
+
+	$desc_link = ''; //wpcf7_link( __( 'http://contactform7.com/text-fields/', 'contact-form-7' ), __( 'Text Fields', 'contact-form-7' ) );
+
+
 	?>
-	<div id="wpcf7-tg-pane-mailpoetsignup" class="hidden">
-	<form action="">
-		<table>
-			<tr>
-				<td>
-					<input type="checkbox" name="required" />&nbsp;<?php echo esc_html( __( 'Required field?', 'wpcf7' ) ); ?>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<?php echo esc_html( __( 'Name', 'wpcf7' ) ); ?><br /><input type="text" name="name" class="tg-name oneline" />
-				</td>
-				<td></td>
-			</tr>
-		</table>
 
-		<table>
-			<tr>
-				<td>
-					<code>MailPoet Lists</code><br />
-					<?php
-					// print mailpoet lists
-					echo wpcf7_mailpoetsignup_get_list_inputs();
-					?>
-					<br />
-					<code>checked by default (opt-in)</code><br />
-					<input type="checkbox" name="default:on" class="option" />&nbsp;<?php echo esc_html( __( "Make this checkbox checked by default?", 'contact-form-7' ) ); ?>
-				</td>
-				<td>
-					<code>checkbox label</code> <br />
-					<textarea name="values"></textarea>
-				</td>
-			</tr>
-			<tr>
-				<td><code>id</code> (<?php echo esc_html( __( 'optional', 'wpcf7' ) ); ?>)<br />
-					<input type="text" name="id" class="idvalue oneline option" />
-				</td>
-				<td><code>class</code> (<?php echo esc_html( __( 'optional', 'wpcf7' ) ); ?>)<br />
-					<input type="text" name="class" class="classvalue oneline option" />
-				</td>
-			</tr>
+<div class="control-box">
+<fieldset>
+<legend><?php echo esc_html( $description ); ?></legend>
 
-		</table>
+<table class="form-table">
+<tbody>
+	<tr>
+	<th scope="row"><?php echo esc_html( __( 'Field type', 'mpcf7' ) ); ?></th>
+	<td>
+		<fieldset>
+		<legend class="screen-reader-text"><?php echo esc_html( __( 'Field type', 'contact-form-7' ) ); ?></legend>
+		<label><input type="checkbox" name="required" /> <?php echo esc_html( __( 'Required field', 'contact-form-7' ) ); ?></label>
+		</fieldset>
+	</td>
+	</tr>
 
-		<div class="tg-tag"><?php echo esc_html( __( "Copy this code and paste it into the form left.", 'wpcf7' ) ); ?><br /><input type="text" name="mailpoetsignup" class="tag" readonly="readonly" onfocus="this.select()" /></div>
+	<tr>
+	<th scope="row"><?php echo esc_html( __( 'MailPoet Lists', 'contact-form-7' ) ); ?></th>
+	<td>					
+		<?php
+		// print mailpoet lists
+		echo wpcf7_mailpoetsignup_get_list_inputs();
+		?>
+	</td>
+	</tr>
 
-		<div class="tg-mail-tag"><?php echo esc_html( __( "And, put this code into the Mail fields below.", 'wpcf7' ) ); ?><br /><span class="arrow">&#11015;</span>&nbsp;<input type="text" class="mail-tag" readonly="readonly" onfocus="this.select()" /></div>
-	</form>
+	<tr>
+	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-default:on' ); ?>"><?php echo esc_html( __( 'Checked by Default', 'mpcf7' ) ); ?></label></th>
+	<td><input type="checkbox" name="default:on" class="option" />&nbsp;<?php echo esc_html( __( "Make this checkbox checked by default?", 'contact-form-7' ) ); ?></td>
+	</tr>
+
+	<tr>
+	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-values' ); ?>"><?php echo esc_html( __( 'Checkbox Label', 'mpcf7' ) ); ?></label></th>
+	<td><input type="text" name="values" class="oneline" id="<?php echo esc_attr( $args['content'] . '-values' ); ?>" /><br />
+	</tr>
+
+	<tr>
+	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php echo esc_html( __( 'Name', 'contact-form-7' ) ); ?></label></th>
+	<td><input type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>" /></td>
+	</tr>
+
+	<tr>
+	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-id' ); ?>"><?php echo esc_html( __( 'Id attribute', 'contact-form-7' ) ); ?></label></th>
+	<td><input type="text" name="id" class="idvalue oneline option" id="<?php echo esc_attr( $args['content'] . '-id' ); ?>" /></td>
+	</tr>
+
+	<tr>
+	<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-class' ); ?>"><?php echo esc_html( __( 'Class attribute', 'contact-form-7' ) ); ?></label></th>
+	<td><input type="text" name="class" class="classvalue oneline option" id="<?php echo esc_attr( $args['content'] . '-class' ); ?>" /></td>
+	</tr>
+
+</tbody>
+</table>
+</fieldset>
+</div>
+
+<div class="insert-box">
+	<input type="text" name="<?php echo $type; ?>" class="tag code" readonly="readonly" onfocus="this.select()" />
+
+	<div class="submitbox">
+	<input type="button" class="button button-primary insert-tag" value="<?php echo esc_attr( __( 'Insert Tag', 'contact-form-7' ) ); ?>" />
 	</div>
+
+	<br class="clear" />
+
+	<p class="description mail-tag"><label for="<?php echo esc_attr( $args['content'] . '-mailtag' ); ?>"><?php echo sprintf( esc_html( __( "To use the value input through this field in a mail field, you need to insert the corresponding mail-tag (%s) into the field on the Mail tab.", 'contact-form-7' ) ), '<strong><span class="mail-tag"></span></strong>' ); ?><input type="text" class="mail-tag code hidden" readonly="readonly" id="<?php echo esc_attr( $args['content'] . '-mailtag' ); ?>" /></label></p>
+</div>
+
 	<?php
 }
 


### PR DESCRIPTION
Updated wpcf7_add_tag_generator_mailpoetsignup() and wpcf7_tg_pane_mailpoetsignup() to recent code practices with CF7 plugin.

CF7 now loads their fields differently, in fact, their whole admin area has changed. I viewed the code for adding a textarea and applied it to the mailpoet form field. 